### PR TITLE
Strict null object dependencies

### DIFF
--- a/lib/subst_attr/controls/dependency.rb
+++ b/lib/subst_attr/controls/dependency.rb
@@ -8,7 +8,7 @@ module SubstAttr
 
         module Substitute
           def self.build
-            :some_substutute
+            :some_substitute
           end
         end
 

--- a/lib/subst_attr/controls/dependency.rb
+++ b/lib/subst_attr/controls/dependency.rb
@@ -3,7 +3,7 @@ module SubstAttr
     module Dependency
       class Example
         def self.configure(receiver)
-          receiver.some_attr = new
+          receiver.specialized_substitute_attr = new
         end
 
         module Substitute

--- a/lib/subst_attr/controls/dependency.rb
+++ b/lib/subst_attr/controls/dependency.rb
@@ -15,6 +15,11 @@ module SubstAttr
         class Descendant < Example
         end
       end
+
+      module NoSubstitute
+        class Example
+        end
+      end
     end
   end
 end

--- a/lib/subst_attr/controls/example.rb
+++ b/lib/subst_attr/controls/example.rb
@@ -5,6 +5,8 @@ module SubstAttr
 
       subst_attr :some_attr, Dependency::Example
 
+      subst_attr :no_substitute_attr, Dependency::NoSubstitute::Example
+
       subst_attr :weak_attr
 
       def self.build

--- a/lib/subst_attr/controls/example.rb
+++ b/lib/subst_attr/controls/example.rb
@@ -3,11 +3,11 @@ module SubstAttr
     class Example
       include SubstAttr
 
-      subst_attr :some_attr, Dependency::Example
+      subst_attr :specialized_substitute_attr, Dependency::Example
 
-      subst_attr :no_substitute_attr, Dependency::NoSubstitute::Example
+      subst_attr :strict_substitute_attr, Dependency::NoSubstitute::Example
 
-      subst_attr :weak_attr
+      subst_attr :weak_substitute_attr
 
       def self.build
         new.tap do |instance|

--- a/lib/subst_attr/substitute.rb
+++ b/lib/subst_attr/substitute.rb
@@ -29,6 +29,10 @@ module SubstAttr
 
       specialization_module = reflection.constant
 
+      if specialization_module.equal?(self)
+        return nil
+      end
+
       unless specialization_module.respond_to?(:build)
         return nil
       end

--- a/test/automated/null_object/specialized.rb
+++ b/test/automated/null_object/specialized.rb
@@ -1,0 +1,11 @@
+require_relative '../automated_init'
+
+context "Null Object" do
+  context "Specialized" do
+    example = Controls::Example.new
+
+    test "Attribute value is the substitute" do
+      assert(example.specialized_substitute_attr == :some_substitute)
+    end
+  end
+end

--- a/test/automated/null_object/strict.rb
+++ b/test/automated/null_object/strict.rb
@@ -2,7 +2,7 @@ require_relative '../automated_init'
 
 context "Null Object" do
   context "Strict" do
-    example = Controls::Example.build
+    example = Controls::Example.new
 
     context "Invoking Methods Not Implemented on the Impersonated Class" do
       test "Is an error" do

--- a/test/automated/null_object/strict.rb
+++ b/test/automated/null_object/strict.rb
@@ -4,25 +4,17 @@ context "Null Object" do
   context "Strict" do
     example = Controls::Example.new
 
-    context "Attribute Has A Specialized Substitute" do
-      test "Attribute value is the substitute" do
-        assert(example.some_attr == :some_substitute)
+    context "Invoking Methods Not Implemented on the Impersonated Class" do
+      test "Is an error" do
+        assert_raises(NoMethodError) do
+          example.strict_substitute_attr.some_method
+        end
       end
     end
 
-    context "Attribute Lacks A Specialized Substitute" do
-      context "Invoking Methods Not Implemented on the Impersonated Class" do
-        test "Is an error" do
-          assert_raises(NoMethodError) do
-            example.no_substitute_attr.some_method
-          end
-        end
-      end
-
-      context "Recording" do
-        test "Not a recorder" do
-          refute(example.no_substitute_attr.is_a? Mimic::Recorder)
-        end
+    context "Recording" do
+      test "Not a recorder" do
+        refute(example.strict_substitute_attr.is_a? Mimic::Recorder)
       end
     end
   end

--- a/test/automated/null_object/strict.rb
+++ b/test/automated/null_object/strict.rb
@@ -14,7 +14,7 @@ context "Null Object" do
 
     context "Recording" do
       test "Not a recorder" do
-        refute(example.is_a? Mimic::Recorder)
+        refute(example.some_attr.is_a? Mimic::Recorder)
       end
     end
   end

--- a/test/automated/null_object/strict.rb
+++ b/test/automated/null_object/strict.rb
@@ -4,17 +4,25 @@ context "Null Object" do
   context "Strict" do
     example = Controls::Example.new
 
-    context "Invoking Methods Not Implemented on the Impersonated Class" do
-      test "Is an error" do
-        assert_raises(NoMethodError) do
-          example.some_attr.some_method
-        end
+    context "Attribute Has A Specialized Substitute" do
+      test "Attribute value is the substitute" do
+        assert(example.some_attr == :some_substitute)
       end
     end
 
-    context "Recording" do
-      test "Not a recorder" do
-        refute(example.some_attr.is_a? Mimic::Recorder)
+    context "Attribute Lacks A Specialized Substitute" do
+      context "Invoking Methods Not Implemented on the Impersonated Class" do
+        test "Is an error" do
+          assert_raises(NoMethodError) do
+            example.no_substitute_attr.some_method
+          end
+        end
+      end
+
+      context "Recording" do
+        test "Not a recorder" do
+          refute(example.no_substitute_attr.is_a? Mimic::Recorder)
+        end
       end
     end
   end

--- a/test/automated/null_object/substitute_module_not_specialized.rb
+++ b/test/automated/null_object/substitute_module_not_specialized.rb
@@ -1,0 +1,30 @@
+require_relative '../automated_init'
+
+context "Null Object" do
+  context "Attribute's Substitute Module Isn't A Specialization" do
+    cls = Class.new do
+      include SubstAttr
+
+      def some_method
+      end
+    end
+    assert(cls::Substitute == SubstAttr::Substitute)
+
+    substitute = SubstAttr::Substitute.build(cls)
+
+    compare_methods = substitute.methods - Mimic.preserved_methods
+    compare_methods.sort!
+
+    control_methods = Mimic.subject_methods(cls).map { |method| method.name }
+    control_methods.sort!
+
+    comment "Substitute Methods: #{compare_methods.inspect}"
+    detail "Control Methods: #{control_methods.inspect}"
+
+    is_strict_null_object = compare_methods == control_methods
+
+    test "Strict null object" do
+      assert(is_strict_null_object)
+    end
+  end
+end

--- a/test/automated/null_object/weak.rb
+++ b/test/automated/null_object/weak.rb
@@ -7,14 +7,14 @@ context "Null Object" do
     context "Invoking Methods Not Implemented" do
       test "Is not an error" do
         refute_raises(NoMethodError) do
-          example.weak_attr.some_method
+          example.weak_substitute_attr.some_method
         end
       end
     end
 
     context "Recording" do
       test "Not a recorder" do
-        refute(example.weak_attr.is_a? Mimic::Recorder)
+        refute(example.weak_substitute_attr.is_a? Mimic::Recorder)
       end
     end
   end

--- a/test/automated/null_object/weak.rb
+++ b/test/automated/null_object/weak.rb
@@ -14,7 +14,7 @@ context "Null Object" do
 
     context "Recording" do
       test "Not a recorder" do
-        refute(example.is_a? Mimic::Recorder)
+        refute(example.weak_attr.is_a? Mimic::Recorder)
       end
     end
   end

--- a/test/automated/null_object/weak.rb
+++ b/test/automated/null_object/weak.rb
@@ -2,7 +2,7 @@ require_relative '../automated_init'
 
 context "Null Object" do
   context "Weak" do
-    example = Controls::Example.build
+    example = Controls::Example.new
 
     context "Invoking Methods Not Implemented" do
       test "Is not an error" do

--- a/test/automated/substitute/ancestor_dependency.rb
+++ b/test/automated/substitute/ancestor_dependency.rb
@@ -5,7 +5,7 @@ context "Substitute" do
     example = Controls::Example::Ancestry::Example.new
 
     test do
-      assert(example.some_attr == :some_substutute)
+      assert(example.some_attr == :some_substitute)
     end
   end
 end

--- a/test/automated/substitute/replace.rb
+++ b/test/automated/substitute/replace.rb
@@ -8,7 +8,7 @@ context "Substitute" do
     SubstAttr::Substitute.(:some_attr, example)
 
     test "Attribute is replaced with its substitute" do
-      assert(example.some_attr == :some_substutute)
+      assert(example.some_attr == :some_substitute)
     end
   end
 end

--- a/test/automated/substitute/replace.rb
+++ b/test/automated/substitute/replace.rb
@@ -3,12 +3,12 @@ require_relative '../automated_init'
 context "Substitute" do
   context "Replace an Attribute with its Substitute" do
     example = Controls::Example.build
-    assert(example.some_attr.is_a?(Controls::Dependency::Example))
+    assert(example.specialized_substitute_attr.is_a?(Controls::Dependency::Example))
 
-    SubstAttr::Substitute.(:some_attr, example)
+    SubstAttr::Substitute.(:specialized_substitute_attr, example)
 
     test "Attribute is replaced with its substitute" do
-      assert(example.some_attr == :some_substitute)
+      assert(example.specialized_substitute_attr == :some_substitute)
     end
   end
 end

--- a/test/automated/substitute/return_value.rb
+++ b/test/automated/substitute/return_value.rb
@@ -3,9 +3,9 @@ require_relative '../automated_init'
 context "Substitute" do
   context "Return Value" do
     example = Controls::Example.build
-    assert(example.some_attr.is_a?(Controls::Dependency::Example))
+    assert(example.specialized_substitute_attr.is_a?(Controls::Dependency::Example))
 
-    some_substitute = SubstAttr::Substitute.(:some_attr, example)
+    some_substitute = SubstAttr::Substitute.(:specialized_substitute_attr, example)
 
     test "Return value is the substitute" do
       assert(some_substitute == :some_substitute)

--- a/test/automated/substitute/return_value.rb
+++ b/test/automated/substitute/return_value.rb
@@ -8,7 +8,7 @@ context "Substitute" do
     some_substitute = SubstAttr::Substitute.(:some_attr, example)
 
     test "Return value is the substitute" do
-      assert(some_substitute == :some_substutute)
+      assert(some_substitute == :some_substitute)
     end
   end
 end


### PR DESCRIPTION
Resolves [dependency issue #4](https://github.com/eventide-project/dependency/issues/4)

Essentially, when a class includes SubstAttr, ruby imports the SubstAttr::Substitute module into the class's namespace:

``` ruby
class SomeClass
  include SubstAttr
end

# In Ruby, "include SubstAttr" will import SubstAttr::Substitute into SomeClass's namespace
assert(SomeClass::Substitute == SubstAttr::Substitute)
```

This is problematic, as it causes SubstAttr to incorrectly provide a weak null object when SomeClass is declared as a dependency of another class:

``` ruby
class OtherClass
  include SubstAttr
  
  subst_attr :some_attr, SomeClass
end

obj = OtherClass.new

# Should raise a NoMethodError
obj.some_attr.some_method
```

Since `obj.some_attr` is supposed to be a strict null object, this should raise a NoMethodError. The fact that it doesn't is a malfunction addressed by this PR.